### PR TITLE
Stop printing arguments to stdout

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -11,8 +11,6 @@ var argv = require('minimist')(process.argv.slice(2), {
   }
 })
 
-console.log('yo', argv)
-
 function usage (exit) {
   var out = exit === 1 ? process.stderr : process.stdout
   fs.createReadStream(path.join(__dirname, 'usage.txt')).pipe(out)


### PR DESCRIPTION
Means redirecting output to a file produces invalid GeoJson